### PR TITLE
Fixed timeout trigger when module is disconnected

### DIFF
--- a/VL6180X.cpp
+++ b/VL6180X.cpp
@@ -343,7 +343,9 @@ void VL6180X::stopContinuous()
 uint8_t VL6180X::readRangeContinuous()
 {
   uint16_t millis_start = millis();
-  while ((readReg(RESULT__INTERRUPT_STATUS_GPIO) & 0x04) == 0)
+  // While computation is not finished
+  // only watching if bits 2:0 (mask 0x07) are set to 0b100 (0x04)
+  while ((readReg(RESULT__INTERRUPT_STATUS_GPIO) & 0x07) != 0x04)
   {
     if (io_timeout > 0 && ((uint16_t)millis() - millis_start) > io_timeout)
     {
@@ -364,7 +366,9 @@ uint8_t VL6180X::readRangeContinuous()
 uint16_t VL6180X::readAmbientContinuous()
 {
   uint16_t millis_start = millis();
-  while ((readReg(RESULT__INTERRUPT_STATUS_GPIO) & 0x20) == 0)
+  // While computation is not finished
+  // only watching if bits 5:3 (mask 0x38) are set to 0b100 (0x20)
+  while ((readReg(RESULT__INTERRUPT_STATUS_GPIO) & 0x38) != 0x20)
   {
     if (io_timeout > 0 && ((uint16_t)millis() - millis_start) > io_timeout)
     {


### PR DESCRIPTION
Problem : when module is disconnected from I²C, `(readReg(RESULT__INTERRUPT_STATUS_GPIO)` return 0xFF, so program does not enter `while` loop and exits without triggering a "timeout", thinking computation was a success.

Solution :

Line 346 : instead of looping while bits 2:0 are equal to 0b000 (= computation not ended, loop again), checks if bits 2:0 are 0b100 as specified in the PDF below to exit loop. That way, when module is disconnected from I²C and `readReg=255`, program stays in loop until timeout occurs.

Line 369 : same as above but for bits 5:3, we check if bits are equal to 0b100 (so whole byte equal 0b10 0000) to exit `while` loop.

Source : [STMicroelectronics](https://www.st.com/resource/en/design_tip/dt0037-vl6180x-range-and-ambient-light-sensor-quick-setup-guide-stmicroelectronics.pdf)