### PR TITLE
Add readRangeStatus method for error codes evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Several example sketches are available that show how to use the library. You can
 * `bool timeoutOccurred(void)`<br>
   Indicates whether a read timeout has occurred since the last call to `timeoutOccurred()`.
 
+* `uint8_t readRangeStatus()`<br>
+  Get ranging success/error status code (Use it before using a measurement).
+
 ## Version history
 * 1.3.1 (2021 Jun 29): Fixed compilation errors with Arduino mbed core.
 * 1.3.0 (2021 Jan 12): Added support for alternative I²C buses (thanks mjs513) and `getAddress()`. Fixed some minor code and documentation issues.

--- a/VL6180X.cpp
+++ b/VL6180X.cpp
@@ -387,3 +387,10 @@ bool VL6180X::timeoutOccurred()
   did_timeout = false;
   return tmp;
 }
+
+// Get ranging success/error status code (Use it before using a measurement)
+// Return error code; One of possible VL6180X_ERROR_* values
+uint8_t VL6180X::readRangeStatus()
+{
+  return (readReg(RESULT__RANGE_STATUS) >> 4);
+}

--- a/VL6180X.h
+++ b/VL6180X.h
@@ -4,6 +4,21 @@
 #include <Arduino.h>
 #include <Wire.h>
 
+#define VL6180X_ERROR_NONE          0   // No error; Valid measurement
+#define VL6180X_ERROR_SYSERR_1      1   // System error; VCSEL Continuity Test; No measurement possible
+#define VL6180X_ERROR_SYSERR_2      2   // System error; VCSEL Watchdog Test; No measurement possible
+#define VL6180X_ERROR_SYSERR_3      3   // System error; VCSEL Watchdog; No measurement possible
+#define VL6180X_ERROR_SYSERR_4      4   // System error; PLL1 Lock; No measurement possible
+#define VL6180X_ERROR_SYSERR_5      5   // System error; PLL2 Lock; No measurement possible
+#define VL6180X_ERROR_ECEFAIL       6   // Early Convergence Estimate; Check fail
+#define VL6180X_ERROR_NOCONVERGE    7   // Max convergence; System didn't converge before the specified time limit
+#define VL6180X_ERROR_RANGEIGNORE   8   // Range ignore; No Target Ignore; Ignore threshold check failed
+#define VL6180X_ERROR_SNR           11  // Max Signal To Noise Ratio; Ambient conditions too high
+#define VL6180X_ERROR_RAWUFLOW      12  // Raw Range underflow; Target too close
+#define VL6180X_ERROR_RAWOFLOW      13  // Raw Range overflow; Target too far
+#define VL6180X_ERROR_RANGEUFLOW    14  // Range underflow; Target too close
+#define VL6180X_ERROR_RANGEOFLOW    15  // Range overflow; Target too far
+
 class VL6180X
 {
   public:
@@ -122,6 +137,8 @@ class VL6180X
     inline void setTimeout(uint16_t timeout) { io_timeout = timeout; }
     inline uint16_t getTimeout() { return io_timeout; }
     bool timeoutOccurred();
+
+    uint8_t readRangeStatus();
 
   private:
     TwoWire *bus;


### PR DESCRIPTION
Hi, I propose you an improvement concerning the retrieval of error codes reported by the sensor.
This addition seems important because it is mentioned in the doc (p27, Range error codes) that an application should always check the error codes before working on the measured data (which might be incorrect).

The addition is inspired loosely by the Adafruit implementation, with a more complete documentation.

Thanks for reading