### PR TITLE
only change sensor address if the device register updated

### DIFF
--- a/VL6180X.cpp
+++ b/VL6180X.cpp
@@ -27,7 +27,9 @@ VL6180X::VL6180X()
 void VL6180X::setAddress(uint8_t new_addr)
 {
   writeReg(I2C_SLAVE__DEVICE_ADDRESS, new_addr & 0x7F);
-  address = new_addr;
+  if (last_status == 0) {
+    address = new_addr;
+  }
 }
 
 // Initialize sensor with settings from ST application note AN4545, section


### PR DESCRIPTION
I've had a few issues where writing to the device fails and the address is updated anyway. Not a great way to debug that, since the `get_address` function simply returns the locally saved address. This, however, allows you to check if the write was successful by comparing the local address and your desired address after the fact. There are other ways to check the success, but I feel like not updating the local address is more expected than updating it even if it fails.